### PR TITLE
Watch-deps now triggers on Mac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,6 @@
 
 ## Fixed
 
+* Watch-deps now triggers on Mac
+
 ## Changed

--- a/src/lambdaisland/classpath/watch_deps.clj
+++ b/src/lambdaisland/classpath/watch_deps.clj
@@ -1,6 +1,7 @@
 (ns lambdaisland.classpath.watch-deps
   "Watch deps.edn for changes"
   (:require [clojure.java.classpath :as cp]
+            [clojure.string :as str]
             [clojure.tools.deps.alpha :as deps]
             [lambdaisland.classpath :as licp]
             [nextjournal.beholder :as beholder]))
@@ -9,7 +10,7 @@
 
 (defn- on-event [opts {:keys [type path]}]
   (when (and (= :modify type)
-             (= "./deps.edn" (str path)))
+             (str/ends-with? (str path) "./deps.edn"))
     (println "✨ Reloading deps.edn ✨")
     (let [new-paths (remove (set (map str (cp/system-classpath)))
                             (:classpath-roots (deps/create-basis opts)))]

--- a/src/lambdaisland/classpath/watch_deps.clj
+++ b/src/lambdaisland/classpath/watch_deps.clj
@@ -10,6 +10,9 @@
 
 (defn- on-event [opts {:keys [type path]}]
   (when (and (= :modify type)
+             ;; On Mac the path will be absolute and include the watched dir,
+             ;; e.g. `/Users/x/project/./deps.edn`
+             ;; On other systems it seems to be relative, like `./deps.edn`
              (str/ends-with? (str path) "./deps.edn"))
     (println "✨ Reloading deps.edn ✨")
     (let [new-paths (remove (set (map str (cp/system-classpath)))


### PR DESCRIPTION
The Mac directory watcher gives the event the absolute  path instead of the relative path. This patch reloads deps whenever a path that ends in `./deps.edn` changes.
