### PR TITLE
Fix the typo in README and one of the docstring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fix typo in the README's example and one in doc-string
+
 ## Added
 
 ## Fixed

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Add/override the classpath based on the current deps.edn.
 Access specific class loaders
 
 ```clojure
-(licp/context-class-loader)
+(licp/context-classloader)
 (licp/base-loader)
 (licp/root-loader)
 (licp/compiler-loader)

--- a/src/lambdaisland/classpath.clj
+++ b/src/lambdaisland/classpath.clj
@@ -94,7 +94,7 @@
   (clojure.lang.RT/baseLoader))
 
 (defn cl-name
-  "Get a classlaoders's defined name"
+  "Get a classloaders's defined name"
   [^ClassLoader cl]
   (.getName cl))
 


### PR DESCRIPTION
Minor improvement to fix the typo.
Thanks for a great library.